### PR TITLE
Fix release changelog

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Setting `fetch-depth: 0` does a deep clone so we have more history than just the latest HEAD.